### PR TITLE
docs: add component documentation templates

### DIFF
--- a/docs/components/edc-connector.md
+++ b/docs/components/edc-connector.md
@@ -1,0 +1,29 @@
+﻿# EDC Connector
+
+## Repository
+
+https://github.com/deployEMDS/edc_connector
+
+## Responsible partner / owner
+
+TBD
+
+## Technical contact
+
+TBD
+
+## Component description
+
+_To be completed by the component owner._
+
+## Deployment information
+
+_To be completed by the component owner._
+
+## Licensing information
+
+_To be completed by the component owner._
+
+## Additional notes
+
+_To be completed by the component owner._

--- a/docs/components/etds-ui.md
+++ b/docs/components/etds-ui.md
@@ -1,0 +1,29 @@
+﻿# ETDS UI
+
+## Repository
+
+https://github.com/deployEMDS/edc_connector_ui
+
+## Responsible partner / owner
+
+TBD
+
+## Technical contact
+
+TBD
+
+## Component description
+
+_To be completed by the component owner._
+
+## Deployment information
+
+_To be completed by the component owner._
+
+## Licensing information
+
+_To be completed by the component owner._
+
+## Additional notes
+
+_To be completed by the component owner._

--- a/docs/components/federated-catalog.md
+++ b/docs/components/federated-catalog.md
@@ -1,0 +1,29 @@
+﻿# Federated Catalog
+
+## Repository
+
+TBD
+
+## Responsible partner / owner
+
+TBD
+
+## Technical contact
+
+TBD
+
+## Component description
+
+_To be completed by the component owner._
+
+## Deployment information
+
+_To be completed by the component owner._
+
+## Licensing information
+
+_To be completed by the component owner._
+
+## Additional notes
+
+_To be completed by the component owner._

--- a/docs/components/identity-management.md
+++ b/docs/components/identity-management.md
@@ -1,0 +1,29 @@
+﻿# Identity Management
+
+## Repository
+
+https://github.com/deployEMDS/identity-management
+
+## Responsible partner / owner
+
+TBD
+
+## Technical contact
+
+TBD
+
+## Component description
+
+_To be completed by the component owner._
+
+## Deployment information
+
+_To be completed by the component owner._
+
+## Licensing information
+
+_To be completed by the component owner._
+
+## Additional notes
+
+_To be completed by the component owner._

--- a/docs/components/vocabulary-hub.md
+++ b/docs/components/vocabulary-hub.md
@@ -1,0 +1,29 @@
+﻿# Vocabulary Hub
+
+## Repository
+
+https://github.com/deployEMDS/VocabularyHub
+
+## Responsible partner / owner
+
+TBD
+
+## Technical contact
+
+TBD
+
+## Component description
+
+_To be completed by the component owner._
+
+## Deployment information
+
+_To be completed by the component owner._
+
+## Licensing information
+
+_To be completed by the component owner._
+
+## Additional notes
+
+_To be completed by the component owner._

--- a/docs/deployment/deployment-overview.md
+++ b/docs/deployment/deployment-overview.md
@@ -1,0 +1,11 @@
+﻿# Deployment Overview
+
+This page will provide a high-level overview of the deployment-related repositories and references.
+
+Detailed deployment information should remain in the corresponding deployment repositories.
+
+| Deployment area | Repository | Responsible partner / owner | Status |
+|---|---|---|---|
+| Kubernetes deployment | https://github.com/deployEMDS/deployEMDS-k8s-deployment | TBD | To be completed |
+| Docker deployment | TBD | TBD | To be completed |
+| Infrastructure automation | TBD | TBD | To be completed |

--- a/docs/licensing/licensing-overview.md
+++ b/docs/licensing/licensing-overview.md
@@ -1,0 +1,14 @@
+﻿# Licensing Overview
+
+This page will provide a consolidated overview of the licensing information for the ETDS technical components.
+
+Each component repository remains the authoritative source for its own license. The information below should be completed and validated by the responsible component owner.
+
+| Component / Repository | Repository | License | Notes |
+|---|---|---|---|
+| Federated Catalog | TBD | TBD | Repository link pending. |
+| EDC Connector | https://github.com/deployEMDS/edc_connector | TBD | To be completed by the component owner. |
+| Vocabulary Hub | https://github.com/deployEMDS/VocabularyHub | TBD | To be completed by the component owner. |
+| Identity Management | https://github.com/deployEMDS/identity-management | TBD | To be completed by the component owner. |
+| ETDS UI | https://github.com/deployEMDS/edc_connector_ui | TBD | To be completed by the component owner. |
+| Kubernetes Deployment | https://github.com/deployEMDS/deployEMDS-k8s-deployment | TBD | To be completed by the repository owner. |

--- a/docs/licensing/licensing-overview.md
+++ b/docs/licensing/licensing-overview.md
@@ -10,5 +10,5 @@ Each component repository remains the authoritative source for its own license. 
 | EDC Connector | https://github.com/deployEMDS/edc_connector | TBD | To be completed by the component owner. |
 | Vocabulary Hub | https://github.com/deployEMDS/VocabularyHub | TBD | To be completed by the component owner. |
 | Identity Management | https://github.com/deployEMDS/identity-management | TBD | To be completed by the component owner. |
-| ETDS UI | https://github.com/deployEMDS/edc_connector_ui | TBD | To be completed by the component owner. |
+| dEMDS UI | https://github.com/deployEMDS/edc_connector_ui | TBD | To be completed by the component owner. |
 | Kubernetes Deployment | https://github.com/deployEMDS/deployEMDS-k8s-deployment | TBD | To be completed by the repository owner. |


### PR DESCRIPTION
This PR adds the initial documentation structure for the main ETDS components, including component templates, deployment overview and licensing overview.

The component files are intended to be completed by the corresponding component owners.

Initial components included:
- Federated Catalog
- EDC Connector
- Vocabulary Hub
- Identity Management
- EMDS UI

Notes:
- The Federated Catalog repository link is still pending.
- No detailed component descriptions have been added yet; only templates and repository references have been included.
- Deployment and licensing sections are also initial templates to be completed by the relevant owners.

Could you please review whether this structure is suitable as a starting point? @caspervg 